### PR TITLE
Sidebar widget improvements

### DIFF
--- a/src/skeleton/sidebar/SidebarLayout.vue
+++ b/src/skeleton/sidebar/SidebarLayout.vue
@@ -8,6 +8,7 @@
           :key="index"
           @remove="$emit('removeWidget', index)"
           :editing="editing"
+          :defaults="widget.scaifeConfig.defaults"
         >
           <span slot="heading" class="heading">{{
             displayName(widget.scaifeConfig.displayName)

--- a/src/skeleton/sidebar/SidebarWidget.vue
+++ b/src/skeleton/sidebar/SidebarWidget.vue
@@ -39,7 +39,13 @@
 
 <script>
   export default {
-    props: ['editing'],
+    props: ['editing', 'defaults'],
+    created() {
+      if (this.defaults) {
+        this.open = this.defaults.open;
+        this.fixed = this.defaults.fixed;
+      }
+    },
     data() {
       return {
         open: true,

--- a/src/skeleton/sidebar/SidebarWidget.vue
+++ b/src/skeleton/sidebar/SidebarWidget.vue
@@ -27,11 +27,11 @@
           />
         </span>
       </h2>
-      <div v-if="open" class="sticky-body">
+      <div v-show="open" class="sticky-body">
         <slot name="sticky" />
       </div>
     </div>
-    <div v-if="open" :class="['body', { fixed }]">
+    <div v-show="open" :class="['body', { fixed }]">
       <slot name="body" />
     </div>
   </div>

--- a/src/skeleton/sidebar/SidebarWidget.vue
+++ b/src/skeleton/sidebar/SidebarWidget.vue
@@ -79,6 +79,7 @@
       border-top: 1px solid $gray-200;
     }
     .sticky-block {
+      background: inherit;
       position: sticky;
       top: 0;
       z-index: 1000;


### PR DESCRIPTION
- Prefer `v-show` so components wrapped by `SidebarWidget` aren't destroyed when `open` is toggled
- Pass defaults for open / fixed from a widget's `scaifeConfig`
- Prevent `.sticky-block` background from being transparent (and seeing scrolled content underneath)