### PR TITLE
Add ability to add arbitrary config options at site level

### DIFF
--- a/src/skeleton/plugin.js
+++ b/src/skeleton/plugin.js
@@ -61,6 +61,7 @@ const install = (Vue, options) => {
   Vue.prototype.$scaife = {
     ...Vue.prototype.$scaife,
     skeleton: new Skeleton(options.widgets || [], options.iconMap || {}),
+    config: options.config || {},
   };
 
   Vue.component('FixedSkeleton', FixedSkeleton);


### PR DESCRIPTION
This should allow passing in configuration values that can be available to widgets that vary from site to site.

### Usage

```js
const config = {
  mapAccessToken: 'XXXXXXXXX',
};
Vue.use(SkeletonPlugin, { iconMap, config });
```

Then in the widget:

```js
  computed: {
      accessToken() {
        return this.$scaife.config.mapAccessToken;
      },
  }
```